### PR TITLE
digger: init at 0.6.17

### DIFF
--- a/pkgs/by-name/di/digger-backend/package.nix
+++ b/pkgs/by-name/di/digger-backend/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  atlas,
+}:
+buildGoModule rec {
+  pname = "digger-backend";
+  version = "0.6.71";
+
+  src = fetchFromGitHub {
+    owner = "diggerhq";
+    repo = "digger";
+    rev = "v${version}";
+    hash = "sha256-npid5q3eHRQSJt8rKQ/PVQh5qBIz2V3mzAkCWz/VrrE=";
+  };
+
+  vendorHash = "sha256-qcItUM2wQ4fgFDMGkyymxQugGaRQvn7rrmSzaLtL76Q=";
+  proxyVendor = true;
+
+  CGO_ENABLED = 0;
+
+  nativeBuildInputs = [atlas];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  subPackages = ["backend"];
+
+  postInstall = ''
+    mkdir -p $out/share/digger-backend
+    cp -r $src/backend/templates $out/share/digger-backend/
+    cp -r $src/backend/migrations $out/share/digger-backend/
+    mv $out/bin/backend $out/bin/digger-backend
+  '';
+
+  meta = with lib; {
+    description = "Backend service for Digger, an open source IaC orchestration tool";
+    homepage = "https://github.com/diggerhq/digger";
+    license = licenses.asl20;
+    mainProgram = "digger-backend";
+    maintainers = with maintainers; [aldoborrero];
+  };
+}

--- a/pkgs/by-name/di/digger-cli/package.nix
+++ b/pkgs/by-name/di/digger-cli/package.nix
@@ -1,0 +1,37 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule rec {
+  pname = "digger-cli";
+  version = "0.6.71";
+
+  src = fetchFromGitHub {
+    owner = "diggerhq";
+    repo = "digger";
+    rev = "v${version}";
+    hash = "sha256-npid5q3eHRQSJt8rKQ/PVQh5qBIz2V3mzAkCWz/VrrE=";
+  };
+
+  vendorHash = "sha256-qcItUM2wQ4fgFDMGkyymxQugGaRQvn7rrmSzaLtL76Q=";
+  proxyVendor = true;
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X digger/pkg/utils.version=${version}"
+  ];
+
+  subPackages = ["cli/cmd/digger"];
+
+  meta = with lib; {
+    description = "Digger is an open source IaC orchestration tool. Digger allows you to run IaC in your existing CI pipeline";
+    homepage = "https://github.com/diggerhq/digger";
+    license = licenses.asl20;
+    mainProgram = "digger";
+    maintainers = with maintainers; [aldoborrero];
+  };
+}


### PR DESCRIPTION
Add support for `digger-cli` and `digger-backend`.