### PR TITLE
feat: use custom patched atlas to support postgresql unix socket connections

### DIFF
--- a/pkgs/by-name/di/digger-backend/atlas-postgres-sockets.patch
+++ b/pkgs/by-name/di/digger-backend/atlas-postgres-sockets.patch
@@ -1,0 +1,129 @@
+diff --git a/sql/postgres/driver.go b/sql/postgres/driver.go
+index c03e6beb..5f401221 100644
+--- a/sql/postgres/driver.go
++++ b/sql/postgres/driver.go
+@@ -13,6 +13,7 @@ import (
+ 	"math/rand"
+ 	"net/url"
+ 	"strconv"
++	"strings"
+ 	"time"
+
+ 	"ariga.io/atlas/sql/internal/sqlx"
+@@ -57,7 +58,7 @@ func init() {
+ 		DriverName,
+ 		sqlclient.OpenerFunc(opener),
+ 		sqlclient.RegisterDriverOpener(Open),
+-		sqlclient.RegisterFlavours("postgresql"),
++		sqlclient.RegisterFlavours("postgresql", "psql"),
+ 		sqlclient.RegisterCodec(codec, codec),
+ 		sqlclient.RegisterURLParser(parser{}),
+ 	)
+@@ -401,7 +402,7 @@ type parser struct{}
+
+ // ParseURL implements the sqlclient.URLParser interface.
+ func (parser) ParseURL(u *url.URL) *sqlclient.URL {
+-	return &sqlclient.URL{URL: u, DSN: u.String(), Schema: u.Query().Get("search_path")}
++	return &sqlclient.URL{URL: u, DSN: dsn(u), Schema: u.Query().Get("search_path")}
+ }
+
+ // ChangeSchema implements the sqlclient.SchemaChanger interface.
+@@ -413,6 +414,48 @@ func (parser) ChangeSchema(u *url.URL, s string) *url.URL {
+ 	return &nu
+ }
+
++// dsn returns the PostgresQL standard DSN for opening
++// the sql.DB from the user provided URL.
++func dsn(u *url.URL) string {
++	var b strings.Builder
++	values := u.Query()
++
++	b.WriteString("postgresql://")
++
++	if u.User != nil {
++		b.WriteString(u.User.Username())
++		if pass, ok := u.User.Password(); ok {
++			b.WriteByte(':')
++			b.WriteString(pass)
++		}
++		b.WriteByte('@')
++	}
++
++	if u.Host != "" {
++		b.WriteString(u.Host)
++	}
++
++	if path := strings.TrimPrefix(u.Path, "/"); path != "" {
++		b.WriteByte('/')
++		b.WriteString(path)
++	}
++
++	if host := values.Get("host"); host != "" {
++		b.WriteString("?host=")
++		b.WriteString(host)
++		values.Del("host")
++		if p := values.Encode(); p != "" {
++			b.WriteByte('&')
++			b.WriteString(p)
++		}
++	} else if p := values.Encode(); p != "" {
++		b.WriteByte('?')
++		b.WriteString(p)
++	}
++
++	return b.String()
++}
++
+ // Standard column types (and their aliases) as defined in
+ // PostgreSQL codebase/website.
+ const (
+diff --git a/sql/postgres/driver_test.go b/sql/postgres/driver_test.go
+index 4a0025bd..6afe123f 100644
+--- a/sql/postgres/driver_test.go
++++ b/sql/postgres/driver_test.go
+@@ -7,6 +7,7 @@ package postgres
+ import (
+ 	"context"
+ 	"io"
++	"net/url"
+ 	"testing"
+ 	"time"
+
+@@ -18,6 +19,36 @@ import (
+ 	"github.com/stretchr/testify/require"
+ )
+
++func TestParseURL(t *testing.T) {
++	t.Run("StandardDSN", func(t *testing.T) {
++		for u, d := range map[string]string{
++			"postgresql://user:pass@localhost/dbname":              "postgresql://user:pass@localhost/dbname",
++			"postgresql://digger?host=/run/postgresql":             "postgresql://digger?host=/run/postgresql",
++			"postgresql://postgres?host=/var/run/postgresql":       "postgresql://postgres?host=/var/run/postgresql",
++			"postgresql://user@localhost/mydb?sslmode=verify-full": "postgresql://user@localhost/mydb?sslmode=verify-full",
++		} {
++			u1, err := url.Parse(u)
++			require.NoError(t, err)
++			p := parser{}.ParseURL(u1)
++			require.Equal(t, d, p.DSN)
++		}
++	})
++
++	t.Run("Schema", func(t *testing.T) {
++		for u, s := range map[string]string{
++			"postgresql://user:pass@localhost/dbname?search_path=public":    "public",
++			"postgresql://localhost/mydb?search_path=app,public":            "app,public",
++			"postgresql:///postgres?host=/var/run/postgresql":               "",
++			"postgresql://user@localhost/mydb?search_path=custom&sslmode=1": "custom",
++		} {
++			u1, err := url.Parse(u)
++			require.NoError(t, err)
++			p := parser{}.ParseURL(u1)
++			require.Equal(t, s, p.Schema)
++		}
++	})
++}
++
+ func TestDriver_LockAcquired(t *testing.T) {
+ 	db, m, err := sqlmock.New()
+ 	require.NoError(t, err)
+

--- a/pkgs/by-name/di/digger-backend/package.nix
+++ b/pkgs/by-name/di/digger-backend/package.nix
@@ -2,45 +2,76 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-}:
-buildGoModule rec {
-  pname = "digger-backend";
-  version = "0.6.79";
+}: let
+  patchedAtlas = buildGoModule rec {
+    pname = "atlas";
+    version = "0.29.0";
 
-  src = fetchFromGitHub {
-    owner = "diggerhq";
-    repo = "digger";
-    rev = "v${version}";
-    hash = "sha256-/R52dwgKqpU9ffka5bz9xb7NyoCIu2/AgiWG0TT8nd0=";
+    src = fetchFromGitHub {
+      owner = "ariga";
+      repo = "atlas";
+      rev = "v${version}";
+      hash = "sha256-synQZAOnX5Xw5d7pHPr7eaycf/YErktCjlsPVwbyLks=";
+    };
+
+    modRoot = "cmd/atlas";
+
+    patches = [
+      ./atlas-postgres-sockets.patch
+    ];
+
+    proxyVendor = true;
+    vendorHash = "sha256-bQNcLFSMED5zFxf319fAeLLrVeZMCV/33s9hCm1elFs=";
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v${version}"
+    ];
+
+    subPackages = ["."];
   };
+in
+  buildGoModule rec {
+    pname = "digger-backend";
+    version = "0.6.79";
 
-  vendorHash = "sha256-qcItUM2wQ4fgFDMGkyymxQugGaRQvn7rrmSzaLtL76Q=";
-  proxyVendor = true;
+    src = fetchFromGitHub {
+      owner = "diggerhq";
+      repo = "digger";
+      rev = "v${version}";
+      hash = "sha256-/R52dwgKqpU9ffka5bz9xb7NyoCIu2/AgiWG0TT8nd0=";
+    };
 
-  CGO_ENABLED = 0;
+    vendorHash = "sha256-qcItUM2wQ4fgFDMGkyymxQugGaRQvn7rrmSzaLtL76Q=";
+    proxyVendor = true;
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X main.Version=${version}"
-  ];
+    CGO_ENABLED = 0;
 
-  subPackages = ["backend"];
+    ldflags = [
+      "-s"
+      "-w"
+      "-X main.Version=${version}"
+    ];
 
-  postInstall = ''
-    mv $out/bin/backend $out/bin/digger-backend
+    subPackages = ["backend"];
 
-    # copy migrations
-    mkdir -p $out/share/
-    cp -r $src/backend/migrations $out/share/
-    cp -r $src/backend/templates $out/share/
-  '';
+    postInstall = ''
+      mv $out/bin/backend $out/bin/digger-backend
 
-  meta = with lib; {
-    description = "Backend service for Digger, an open source IaC orchestration tool";
-    homepage = "https://github.com/diggerhq/digger";
-    license = licenses.asl20;
-    mainProgram = "digger-backend";
-    maintainers = with maintainers; [aldoborrero];
-  };
-}
+      # copy migrations
+      mkdir -p $out/share/
+      cp -r $src/backend/migrations $out/share/
+      cp -r $src/backend/templates $out/share/
+    '';
+
+    passthru.atlas = patchedAtlas;
+
+    meta = with lib; {
+      description = "Backend service for Digger, an open source IaC orchestration tool";
+      homepage = "https://github.com/diggerhq/digger";
+      license = licenses.asl20;
+      mainProgram = "digger-backend";
+      maintainers = with maintainers; [aldoborrero];
+    };
+  }


### PR DESCRIPTION
This PR introduces a modified version of `atlas` that uses socket `socket` style URL connections for Postgres.